### PR TITLE
Add support for SIGTRAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Comma-separated values:
 - bus
 - ill
 - fpe
+- trap
 - sys
 - all
 

--- a/libsegfault.cpp
+++ b/libsegfault.cpp
@@ -12,6 +12,7 @@ namespace
   f(BUS) \
   f(ILL) \
   f(FPE) \
+  f(TRAP) \
   f(SYS)
 
 struct S { char const* name; std::size_t len; int num; };
@@ -57,6 +58,7 @@ segabort_init(void)
     signal(SIGILL, segabort_handler);
     signal(SIGABRT, segabort_handler);
     signal(SIGFPE, segabort_handler);
+    signal(SIGTRAP, segabort_handler);
     signal(SIGSYS, segabort_handler);
   }
   else if (*signals)


### PR DESCRIPTION
This is raised by GLib when `G_DEBUG=fatal-criticals` is used.